### PR TITLE
Fixed 'loadmap' crash.

### DIFF
--- a/Hurrican/src/Console.cpp
+++ b/Hurrican/src/Console.cpp
@@ -391,7 +391,7 @@ void ConsoleClass::CheckCommands() {
         this->print(msg.c_str());
 
         // und Level laden
-        if (mapname.substr(mapname.length() - 4) != ".map")
+        if (mapname.length() < 4 || mapname.substr(mapname.length() - 4) != ".map")
             mapname += ".map";
 
         std::string filename = g_storage_ext + "/data/levels/" + mapname;


### PR DESCRIPTION
Fixed a very simple bug where the 'loadmap' command crashed the game when the filename was less then 4 characters.
(Out of bounds 'substr')