### PR TITLE
Pump SDL events before update joystick status

### DIFF
--- a/Hurrican/src/DX8Input.cpp
+++ b/Hurrican/src/DX8Input.cpp
@@ -193,6 +193,7 @@ void DirectInputClass::AcquireKeyboard() {}
 // --------------------------------------------------------------------------------------
 
 void DirectInputClass::UpdateJoysticks() {
+    SDL_PumpEvents();
     for (int i = 0; i < JoysticksFound; i++)
         Joysticks[i].Update();
 }


### PR DESCRIPTION
Avoid hang on button selection in configure controller menu on Windows.