### PR TITLE
added a #undef to remove the warning

### DIFF
--- a/Hurrican/src/DX8Graphics.cpp
+++ b/Hurrican/src/DX8Graphics.cpp
@@ -376,7 +376,7 @@ bool DirectGraphicsClass::SetDeviceInfo() {
 #if defined(USE_GLES1) || defined(USE_GLES2) || defined(USE_GLES3)
     glClearDepthf(1.0f);                   /* Depth buffer setup */
 #else
-    glClearDepth(1.0f);                    /* Depth buffer setup */
+    glClearDepth(1.0);                     /* Depth buffer setup */
 #endif
 
     glDisable(GL_DEPTH_TEST); /* No Depth Testing */

--- a/Hurrican/src/DX8Graphics.cpp
+++ b/Hurrican/src/DX8Graphics.cpp
@@ -372,7 +372,12 @@ bool DirectGraphicsClass::SetDeviceInfo() {
 
     /* Init OpenGL */
     glClearColor(0.0f, 0.0f, 0.0f, 1.0f); /* Set the background black */
-    glClearDepth(1.0f);                   /* Depth buffer setup */
+
+#if defined(USE_GLES1) || defined(USE_GLES2) || defined(USE_GLES3)
+    glClearDepthf(1.0f);                   /* Depth buffer setup */
+#else
+    glClearDepth(1.0f);                    /* Depth buffer setup */
+#endif
 
     glDisable(GL_DEPTH_TEST); /* No Depth Testing */
     glEnable(GL_BLEND);

--- a/Hurrican/src/SDLPort/opengl.hpp
+++ b/Hurrican/src/SDLPort/opengl.hpp
@@ -17,6 +17,7 @@
 #endif
 
 #if defined(USE_GLES1) || defined(USE_GLES2) || defined(USE_GLES3)
+#undef glClearDepth
 #define glClearDepth glClearDepthf
 #endif
 

--- a/Hurrican/src/SDLPort/opengl.hpp
+++ b/Hurrican/src/SDLPort/opengl.hpp
@@ -16,9 +16,4 @@
 #error "ERROR USE_GL2 and USE_GLES1 are defined. Replace USE_GLES1 for USE_GLES2"
 #endif
 
-#if defined(USE_GLES1) || defined(USE_GLES2) || defined(USE_GLES3)
-#undef glClearDepth
-#define glClearDepth glClearDepthf
-#endif
-
 #endif /* _OPENGL_H_ */


### PR DESCRIPTION
This removes a warning when building for GLES.
(redefinition of ```glClearDepth```)
I dont know if this is the right approach to this but it works.