### PR TITLE
Timer fix

### DIFF
--- a/Hurrican/src/Gameplay.cpp
+++ b/Hurrican/src/Gameplay.cpp
@@ -263,26 +263,18 @@ void GameLoop() {
 
     constexpr float SPD_INC = 0.3f;
     float const SpeedFaktorMax = SpeedFaktor;
-    float i = 0;
 
-    while (i < SpeedFaktorMax) {
-        // If the hardware can not render fast enough the logic catch up becomes too large
-        // In this case the logic needs to be broken up into chunks
-        if (SpeedFaktorMax < SPD_INC)  // hardware is fast and sync does not need to be split
-        {
-            SpeedFaktor = SpeedFaktorMax;
-            i = SpeedFaktorMax;
-        } else if (SpeedFaktorMax - i <
-                   SPD_INC)  // sync has been split and only a small value is needed to meet the total sync request
-        {
-            SpeedFaktor = SpeedFaktorMax - i;
-            i = SpeedFaktorMax;
-        } else  // hardware is not fast and sync does need to be split into chunks
-        {
-            SpeedFaktor = SPD_INC;
-            i += SPD_INC;
-        }
+    int chunks = 1;
 
+    // If the hardware can not render fast enough the logic catch up becomes too large
+    // In this case the logic needs to be broken up into chunks
+    if (SpeedFaktorMax > SPD_INC) {
+        chunks = ceilf(SpeedFaktorMax / SPD_INC);
+        SpeedFaktor = SpeedFaktorMax / chunks;
+    }
+
+    // Run the Logic
+    for (int i = 0; i < chunks; i++) {
         for (int p = 0; p < NUMPLAYERS; p++) {
             Player[p].WasDamaged = false;
 

--- a/Hurrican/src/Timer.hpp
+++ b/Hurrican/src/Timer.hpp
@@ -26,6 +26,9 @@
 // Klassen Deklaration
 // --------------------------------------------------------------------------------------
 
+// The Timer class needs the global SpeedFactor variable
+extern float SpeedFaktor;
+
 class TimerClass {
   private:
     std::int64_t vergangeneFrames;  // Vergangene Frames seit Beginn (für Schnitt)
@@ -40,7 +43,6 @@ class TimerClass {
     double vergangeneZeit;     // Zeit seit dem vorherigen Frame
     double aktuelleFramerate;  // Aktuelle Framerate
     int maxFPS;                // Maximum Framerate (Framebremse)
-    float SpeedFaktor;         // Faktor, mit dem alle Werte verrechnet werden
 
   public:
     TimerClass();                   // Konstruktor
@@ -69,7 +71,6 @@ class TimerClass {
 // Externals
 // --------------------------------------------------------------------------------------
 
-extern float SpeedFaktor;
 extern TimerClass Timer;
 
 #endif


### PR DESCRIPTION
This fixes a bug in the game speed calculation (see commit messages).

Steps to reproduce the bug:
Start the game (compiled in debug mode) and enter the command
```
maxfps 10
```
into the console.

I also changed the mechanic, which splits the physic calculations into multiple steps,
when the game runs with a low framerate. The game speed is now even between
these steps.
Please let me know if there is a good reason for the chunks to not be even.