### PR TITLE
Fix ERROR Shader: Could not locate uniform: u_Time

### DIFF
--- a/Hurrican/src/DX8Graphics.cpp
+++ b/Hurrican/src/DX8Graphics.cpp
@@ -447,7 +447,8 @@ bool DirectGraphicsClass::SetDeviceInfo() {
     Shaders[PROGRAM_RENDER].NameClr = Shaders[PROGRAM_RENDER].GetAttribute("a_Color");
     Shaders[PROGRAM_RENDER].NameTex = Shaders[PROGRAM_RENDER].GetAttribute("a_Texcoord0");
     Shaders[PROGRAM_RENDER].NameMvp = Shaders[PROGRAM_RENDER].GetUniform("u_MVPMatrix");
-    NameTime                        = Shaders[PROGRAM_RENDER].GetUniform("u_Time");
+    if (CommandLineParams.ScreenNoise)
+        NameTime                    = Shaders[PROGRAM_RENDER].GetUniform("u_Time");
 #endif /* USE_GL2 || USE_GL3 */
 
     /* Matrices setup */
@@ -577,7 +578,7 @@ void DirectGraphicsClass::RendertoBuffer(GLenum PrimitiveType,
     // Check if the program is already in use
     if (ProgramCurrent != program_next) {
         Shaders[program_next].Use();
-        if (program_next==PROGRAM_RENDER) {
+        if (CommandLineParams.ScreenNoise && (program_next==PROGRAM_RENDER)) {
             glUniform1i(NameTime, 50*SDL_GetTicks()/1000);
         }
         ProgramCurrent = program_next;


### PR DESCRIPTION
Fix `Could not locate uniform: u_Time` shader error when noise is disabled