### PR TITLE
Fixed a bug with the intro

### DIFF
--- a/Hurrican/src/Intro.cpp
+++ b/Hurrican/src/Intro.cpp
@@ -99,7 +99,7 @@ IntroClass::~IntroClass() {
 // --------------------------------------------------------------------------------------
 
 void IntroClass::EndIntro() {
-    if (Zustand != IntroStateEnum::FADEOUT) {
+    if (Zustand != IntroStateEnum::FADEOUT && Zustand != IntroStateEnum::DONE) {
         if (Zustand != IntroStateEnum::FADEIN) {
             Counter = 255.0f;
         }


### PR DESCRIPTION
This fixes a bug:

The intro has a counter which is used to fade it out when a key is pressed.
When the counter reaches 0 the intro state gets changed to DONE.
When a key is still pressed, the function EndIntro will be called and it checks if the
intro state is not FADEOUT, but not for DONE, so it will restart the fade out sequence.

To repoduce this just hold a key pressed when ending the intro, as long as the key is pressed
the intro will always restart the fading.