### PR TITLE
Fix compier warning

### DIFF
--- a/Hurrican/src/Projectiles.cpp
+++ b/Hurrican/src/Projectiles.cpp
@@ -3969,8 +3969,6 @@ void ProjectileClass::ExplodeShot() {
 
             // Prüfen, ob ein Gegner in der Nähe war und dann je nach Abstand
             // Energie abziehen
-            GegnerClass *pEnemy;  // Gegner zum Kollision testen
-
             // je nach bombentyp mehr schaden
             int schaden = 80;
 


### PR DESCRIPTION
This removes a variable (pEnemy) that gets overwritten a few lines later, which causes a compiler warning.