### PR TITLE
Fixed collision check.

### DIFF
--- a/Hurrican/src/Player.cpp
+++ b/Hurrican/src/Player.cpp
@@ -1126,7 +1126,7 @@ void PlayerClass::AnimatePlayer() {
             } else if (Handlung == PlayerActionEnum::BEAMLADEN)  // Rundum bewegen und den Beam aufladen ?
             {
                 BlitzWinkel += Timer.sync(20.0f);
-            } else if (br | BLOCKWERT_WAND)  // Keine Wand im Weg ?
+            } else if (!(br & BLOCKWERT_WAND))  // Keine Wand im Weg ?
             {
                 Blickrichtung = DirectionEnum::RECHTS;  // nach rechts kucken
                 if (Handlung == PlayerActionEnum::STEHEN)  // Aus dem Stehen heraus


### PR DESCRIPTION
This check was a typo. (br | BLOCKWERT_WAND) is always true because BLOCKWERT_WAND == 1. You can see in line 1080, how it was supposed to be, for checking in the left direction.