### PR TITLE
Fixed overlapping in cracktro

### DIFF
--- a/Hurrican/src/CCracktro.cpp
+++ b/Hurrican/src/CCracktro.cpp
@@ -315,8 +315,8 @@ void CCracktro::Load() {
     static float count = 10.0f;
 
     // farbige Balken
-    for (int i = 0; i < 320; i++)
-        RenderRect(0, static_cast<float>(i * 2), RENDERWIDTH, static_cast<float>(i * 2),
+    for (int i = 0; i < (RENDERHEIGHT / 2); i++)
+        RenderRect(0, static_cast<float>(i * 2), RENDERWIDTH, 2,
                    ScrollCol[rand() % (static_cast<int>(sizeof(ScrollCol) / sizeof(D3DCOLOR)))]);
 
     count -= Timer.sync(1.0f);


### PR DESCRIPTION
This code renders the screen full of colored rectangles (when pressing a key to end the cracktro). The height of the rectangles should always only be 2 pixles, otherwise this draws outside of the screen.