### PR TITLE
Skip load screen

### DIFF
--- a/Hurrican/src/Gameplay.cpp
+++ b/Hurrican/src/Gameplay.cpp
@@ -900,6 +900,8 @@ void SaveConfig() {
 // --------------------------------------------------------------------------------------
 
 bool DisplayLoadInfo(const char Text[100]) {
+    return false; // skip loading screen
+
     if (NochKeinFullScreen || pMenu == nullptr)
         return false;
     // TODO FIX


### PR DESCRIPTION
It looks like loading of resources is limited by the frame rate where only one resource per frame is allowed. On modern hardware, loading is quasi instant so I think the screen can just be skipped.